### PR TITLE
fix: skip updating manifest.json if VEX has no changes

### DIFF
--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -1,4 +1,4 @@
-name: Update vexhub
+name: Update VEX Hub
 on:
   schedule:
     - cron: "0 0 * * *" # Every day
@@ -6,7 +6,7 @@ on:
 
 jobs:
   update:
-    name: Update vexhub
+    name: Update VEX Hub
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.ORG_REPO_TOKEN }}


### PR DESCRIPTION
Close https://github.com/aquasecurity/vexhub-crawler/issues/19