### PR TITLE
ci: use the default token

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: ${{ github.repository_owner }}/vexhub
-        token: ${{ secrets.ORG_REPO_TOKEN }}
         path: vexhub
 
     - name: Set up Go


### PR DESCRIPTION
The test workflow doesn't push changes to VEX Hub, so it doesn't need secrets.ORG_REPO_TOKEN, which has more permissions than the default token.