### PR TITLE
Add K3s VEX reports from Rancher's VEX Hub repo

### DIFF
--- a/crawler.yaml
+++ b/crawler.yaml
@@ -2,6 +2,9 @@ pkg:
   golang:
     - namespace: github.com/aquasecurity
       name: trivy
+    - namespace: github.com/k3s-io
+      name: k3s
+      url: https://github.com/rancher/vexhub/tree/main/pkg/golang/github.com/k3s-io/k3s
     - namespace: github.com/rancher
       name: confd
       url: https://github.com/rancher/vexhub/tree/main/pkg/golang/github.com/rancher/confd


### PR DESCRIPTION
Add K3s VEX reports from Rancher's VEX Hub repo. This is a follow-up from https://github.com/aquasecurity/vexhub-crawler/pull/29.