### PR TITLE
Fix diagram's syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ The following diagram illustrates the high-level process flow of the VEX Hub Cra
 
 ```mermaid
 flowchart TD
-    Dev[Developer] -->|1. Register Package| PL[Package List]
-    PL -->|2. Provide packages for crawling| Crawler
-    Crawler -->|3. Identify repository URL| Registry[Package Registry]
-    Crawler -->|4. Retrieve VEX documents| Src
-    Crawler -->|5. Validate and update VEX documents| Hub
+    Dev[Developer] -->|Register package| PL[Package List]
+    PL -->|Provide packages for crawling| Crawler
+    Crawler -->|Identify repository URL| Registry[Package Registry]
+    Crawler -->|Retrieve VEX documents| Src
+    Crawler -->|Validate and update VEX documents| Hub
 
     subgraph crawler [VEX Hub Crawler]
         Crawler
@@ -30,7 +30,7 @@ flowchart TD
         
         subgraph Src[Source Repository]
             direction TB
-            VEX[VEX documents\nunder .vex/ directory]
+            VEX[VEX documents<br>under .vex/ directory]
         end
     end
 


### PR DESCRIPTION
The diagram's labels aren't rendering properly. Now it will look like:

![image](https://github.com/user-attachments/assets/f73be82a-435e-4398-808c-b78cfda08755)
