### PR TITLE
Location field should use forward slashed (in windows too)

### DIFF
--- a/pkg/vexhub/vexhub.go
+++ b/pkg/vexhub/vexhub.go
@@ -43,7 +43,7 @@ func GenerateIndex(root string) error {
 		// Take the first VEX document only
 		index.Packages = append(index.Packages, repo.Package{
 			ID:       m.ID,
-			Location: filepath.Join(rel, m.Sources[0].Path),
+			Location: filepath.ToSlash(filepath.Join(rel, m.Sources[0].Path)),
 		})
 
 		return nil


### PR DESCRIPTION
When writing the ‘location’ field in the index.json file, it depends on the operating system. This causes backslashes to appear in windows instead of the forward slashes that should be used according to the schema specification. This fix forces the use of the appropriate forward slashes regardless of the operating system on which the crawler is running.