### PR TITLE
Make index.json compliant with schema

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"time"
 
 	"github.com/lmittmann/tint"
 	"github.com/samber/oops"
@@ -59,5 +60,6 @@ func run() error {
 		return oops.Wrapf(err, "failed to crawl packages")
 	}
 
-	return oops.Wrap(vexhub.GenerateIndex(*vexHubDir))
+	err = vexhub.GenerateIndex(*vexHubDir, time.Now())
+	return oops.Wrap(err)
 }

--- a/pkg/repo/repo.go
+++ b/pkg/repo/repo.go
@@ -1,9 +1,7 @@
 package repo
 
-import "time"
-
 type Index struct {
-	UpdatedAt time.Time `json:"updated_at"`
+	UpdatedAt string    `json:"updated_at"`
 	Packages  []Package `json:"packages"`
 }
 

--- a/pkg/repo/repo.go
+++ b/pkg/repo/repo.go
@@ -1,8 +1,10 @@
 package repo
 
+import "time"
+
 type Index struct {
-	Version  int       `json:"version"`
-	Packages []Package `json:"packages"`
+	UpdatedAt time.Time `json:"updated_at"`
+	Packages  []Package `json:"packages"`
 }
 
 type Package struct {

--- a/pkg/vexhub/vexhub.go
+++ b/pkg/vexhub/vexhub.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/samber/oops"
 
@@ -17,7 +18,7 @@ func GenerateIndex(root string) error {
 	slog.Info("Generating the index of the VEX Hub")
 	errBuilder := oops.Code("file_walk_error").In("vexhub")
 	index := repo.Index{
-		Version: 1,
+		UpdatedAt: time.Now(),
 	}
 	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
 		errBuilder := oops.With("path", path)

--- a/pkg/vexhub/vexhub.go
+++ b/pkg/vexhub/vexhub.go
@@ -14,11 +14,12 @@ import (
 )
 
 // GenerateIndex generates the index of the VEX Hub
-func GenerateIndex(root string) error {
+func GenerateIndex(root string, updatedAt time.Time) error {
 	slog.Info("Generating the index of the VEX Hub")
+	slog.Debug("UpdatedAt will be " + updatedAt.Format(time.RFC3339Nano))
 	errBuilder := oops.Code("file_walk_error").In("vexhub")
 	index := repo.Index{
-		UpdatedAt: time.Now(),
+		UpdatedAt: updatedAt.Format(time.RFC3339Nano),
 	}
 	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
 		errBuilder := oops.With("path", path)

--- a/pkg/vexhub/vexhub_test.go
+++ b/pkg/vexhub/vexhub_test.go
@@ -18,7 +18,7 @@ func TestGenerateIndex(t *testing.T) {
 		name      string
 		setup     func(root string) error
 		wantErr   require.ErrorAssertionFunc
-		wantIndex func(updatedAt time.Time) string
+		wantIndex string
 	}{
 		{
 			name: "successful index generation",
@@ -42,14 +42,12 @@ func TestGenerateIndex(t *testing.T) {
 				return os.WriteFile(manifestPath, data, 0644)
 			},
 			wantErr: require.NoError,
-			wantIndex: func(updatedAt time.Time) string {
-				return `{
-					"updated_at": "` + updatedAt.Format(time.RFC3339Nano) + `",
+			wantIndex: `{
+					"updated_at": "2025-05-20T17:16:15.123456789Z",
 					"packages": [
 						{ "id" : "package1", "location": "package1/source1" }
 					]
-				}`
-			},
+			}`,
 		},
 	}
 
@@ -67,7 +65,7 @@ func TestGenerateIndex(t *testing.T) {
 			data, err := os.ReadFile(indexPath)
 			require.NoError(t, err)
 
-			require.JSONEq(t, tt.wantIndex(updatedAt), string(data))
+			require.JSONEq(t, tt.wantIndex, string(data))
 		})
 	}
 }

--- a/pkg/vexhub/vexhub_test.go
+++ b/pkg/vexhub/vexhub_test.go
@@ -59,7 +59,7 @@ func TestGenerateIndex(t *testing.T) {
 			err := tt.setup(root)
 			require.NoError(t, err)
 
-			updatedAt := time.Now()
+			updatedAt := time.Date(2025, time.May, 20, 17, 16, 15, 123456789, time.UTC)
 			err = vexhub.GenerateIndex(root, updatedAt)
 			tt.wantErr(t, err)
 


### PR DESCRIPTION
Currently the index.json file generated by the crawler is not compliant with the 0.1 specification for VEX Repository. This is due to the use of a ‘version’ field instead of the ‘updated_at’ field. This proposal changes this in the code.