### PR TITLE
fix(ci): swap `Test` and `Unit tests` steps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,8 +22,8 @@ jobs:
       with:
         go-version-file: go.mod
 
-    - name: Test
-      run: go run main.go -strict -vexhub-dir ./vexhub
-
     - name: Unit tests
       run: go test ./...
+
+    - name: Test
+      run: go run main.go -strict -vexhub-dir ./vexhub


### PR DESCRIPTION
## Description
We got very strange errors (e.g. https://github.com/DmitriyLewen/vexhub-crawler/actions/runs/15109797156/job/42466469765):
```
Error: main.go:13:2: no required module provides package github.com/aquasecurity/vexhub-crawler/pkg/config; to add it:
	go get github.com/aquasecurity/vexhub-crawler/pkg/config
Error: main.go:14:2: no required module provides package github.com/aquasecurity/vexhub-crawler/pkg/crawl; to add it:
	go get github.com/aquasecurity/vexhub-crawler/pkg/crawl
Error: main.go:15:2: no required module provides package github.com/aquasecurity/vexhub-crawler/pkg/vexhub; to add it:
	go get github.com/aquasecurity/vexhub-crawler/pkg/vexhub
Error: Process completed with exit code 1.
```

I didn't find the reason for these errors.
But swapping the `Test` and `Unit tests` steps solves these errors  - https://github.com/DmitriyLewen/vexhub-crawler/actions/runs/15109989686