### PR TITLE
Add the Inspektor Gadget repository

### DIFF
--- a/crawler.yaml
+++ b/crawler.yaml
@@ -41,6 +41,8 @@ pkg:
     - namespace: github.com/harvester
       name: vm-import-controller
       url: https://github.com/rancher/vexhub/tree/main/pkg/golang/github.com/harvester/vm-import-controller
+    - namespace: github.com/inspektor-gadget
+      name: inspektor-gadget
     - namespace: github.com/k3s-io
       name: helm-set-status
       url: https://github.com/rancher/vexhub/tree/main/pkg/golang/github.com/k3s-io/helm-set-status


### PR DESCRIPTION
Hello,

Thanks for providing a mechanism to respond to CVEs in dependencies that are not affecting a project.
With this PR we want to add the Inspektor Gadget vex files to the official vex hub.